### PR TITLE
Check that PRs do not break Asciidoctor build

### DIFF
--- a/.github/workflows/check_adoc_build.yml
+++ b/.github/workflows/check_adoc_build.yml
@@ -1,0 +1,68 @@
+#
+# GitHub Actions Workflow for pull request events against the master branch to
+# make sure Asciidoctor still builds. If successful, the resulting html and
+# pdf files are uploaded as artifacts to make it easier to preview the results
+# of a PR.
+#
+# For more information on the actions used in this workflow, please see:
+#   https://github.com/actions/checkout 
+#   https://github.com/Analog-inc/asciidoctor-action
+#   https://github.com/actions/upload-artifact
+#
+name: Check Asciidoctor Build
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  # Job to build cf-conventions.html, cf-conventions.pdf
+  build_conventions:
+    name: Build cf-conventions html and pdf
+    runs-on: ubuntu-latest
+    steps:
+    # Check out PR
+    - uses: actions/checkout@v2
+    # Create build directory
+    - run: mkdir conventions_build
+    # Build cf-conventions.html using the Analog-inc asciidoctor-action
+    - name: Build cf-conventions.html
+      uses: Analog-inc/asciidoctor-action@v1.2
+      with:
+        shellcommand: 'asciidoctor --verbose cf-conventions.adoc -D conventions_build'
+    # Build cf-conventions.pdf using the Analog-inc asciidoctor-action
+    - name: Build cf-conventions.pdf
+      uses: Analog-inc/asciidoctor-action@v1.2
+      with:
+        shellcommand: 'asciidoctor-pdf --verbose -d book cf-conventions.adoc -D conventions_build'
+    # Upload artifact containing cf-conventions.html, cf-conventions.pdf
+    - name: Upload cf-conventions doc preview
+      uses: actions/upload-artifact@v1
+      with:
+        name: conventions docs
+        path: conventions_build/
+
+  # Job to build conformance.html, conformance.pdf
+  build_conformance:
+    name: Build conformance html and pdf
+    runs-on: ubuntu-latest
+    steps:
+    # Checkout PR
+    - uses: actions/checkout@v2
+    # Create build directory
+    - run: mkdir conformance_build
+    # Build conformance.html using the Analog-inc asciidoctor-action
+    - name: Build conformance.html
+      uses: Analog-inc/asciidoctor-action@v1.2
+      with:
+        shellcommand: 'asciidoctor --verbose conformance.adoc -D conformance_build'
+    # Build conformance.pdf using the Analog-inc asciidoctor-action
+    - name: Build conformance.pdf
+      uses: Analog-inc/asciidoctor-action@v1.2
+      with:
+        shellcommand: 'asciidoctor-pdf --verbose -d book conformance.adoc -D conformance_build'
+    # Upload artifact containing conformance.html, conformance.pdf
+    - name: Upload conformance doc preview
+      uses: actions/upload-artifact@v1
+      with:
+        name: conformance docs
+        path: conformance_build/


### PR DESCRIPTION
This PR enables a github action to check that PRs do not break the
asciidoc build. If the build is successful, the pdf and html files are
uploaded as artifacts to the action, which allow for easier previews of
the generated files.